### PR TITLE
Ensure that dropbear has verbose logging enabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,3 +16,17 @@ echo -e 'Processing historical log data (this can take a while)'
 echo -e 'Starting background process'
 /etc/init.d/bearDropper enable
 /etc/init.d/bearDropper start
+
+dropbear_count=$(uci show dropbear | grep -c =dropbear)
+dropbear_count=$((dropbear_count - 1))
+for instance in $(seq 0 $dropbear_count); do
+  dropbear_verbose=$(uci -q get dropbear.@dropbear[$instance].verbose || echo 0)
+  if [ $dropbear_verbose -eq 0 ]; then
+    uci set dropbear.@dropbear[$instance].verbose=1 
+    dropbear_conf_updated=1
+  fi
+done
+if [ $dropbear_conf_updated ]; then
+  uci commit
+  echo "Verbose logging was configured for dropbear. Please restart the service to enable this change."
+fi


### PR DESCRIPTION
- The "exit before auth" tracking assumes dropbear has logged the IP of
  the child connection. This only occurs when running in verbose mode,
  so ensure that it is enabled when we install.
- Though restarting the main dropbear process should be harmless to
  existing connections, let the user handle it just in case.
