### PR TITLE
Explicitly specify busybox date command

### DIFF
--- a/bearDropper
+++ b/bearDropper
@@ -190,7 +190,7 @@ logLine () {
 getLogTime () {
   local logDateString=`echo "$1" | sed -n \
     's/^[A-Z][a-z]* \([A-Z][a-z]*  *[0-9][0-9]*  *[0-9][0-9]*:[0-9][0-9]:[0-9][0-9] [0-9][0-9]*\) .*$/\1/p'`
-  date -d"$logDateString" -D"$formatLogDate" +%s || logLine 1 \
+  busybox date -d"$logDateString" -D"$formatLogDate" +%s || logLine 1 \
     "Error: logDateString($logDateString) malformed line ($1)"
 }
 
@@ -260,7 +260,7 @@ wipeFirewall () {
 # state db should be more resiliant than the firewall in practice.
 #
 bddbCheckStatusAll () {
-  local now=`date +%s`
+  local now=`busybox date +%s`
   bddbGetAllIPs | while read ip ; do
     if [ `bddbGetStatus $ip` -eq 1 ] ; then
       logLine 3 "bddbCheckStatusAll($ip) testing banLength:$banLength + bddbGetTimes:`bddbGetTimes $ip` vs. now:$now"
@@ -344,14 +344,14 @@ saveState () {
   if [ $bddbStateChange -gt 0 ] ; then
     logLine 3 "saveState() saving to temp state file"
     bddbSave "$fileStateTempPrefix" "$fileStateType"
-    logLine 3 "saveState() now=`date +%s` lPSW=$lastPersistentStateWrite pSWP=$persistentStateWritePeriod fP=$forcePersistent"
+    logLine 3 "saveState() now=`busybox date +%s` lPSW=$lastPersistentStateWrite pSWP=$persistentStateWritePeriod fP=$forcePersistent"
   fi    
   if [ $persistentStateWritePeriod -gt 1 ] || [ $persistentStateWritePeriod -eq 0 -a $forcePersistent -eq 1 ] ; then
-    if [ $((`date +%s` - lastPersistentStateWrite)) -ge $persistentStateWritePeriod ] || [ $forcePersistent -eq 1 ] ; then
+    if [ $((`busybox date +%s` - lastPersistentStateWrite)) -ge $persistentStateWritePeriod ] || [ $forcePersistent -eq 1 ] ; then
       if [ ! -f "$fileStatePersist" ] || ! cmp -s "$fileStateTemp" "$fileStatePersist" ; then
         logLine 2 "saveState() writing to persistent state file"
         bddbSave "$fileStatePersistPrefix" "$fileStateType"
-        lastPersistentStateWrite="`date +%s`"
+        lastPersistentStateWrite="`busybox date +%s`"
   fi ; fi ; fi
 }
 
@@ -430,7 +430,7 @@ fileRegex="/tmp/bearDropper.$$.regex"
 uciLoad logRegex 's/[`$"'\\\'']//g' '/has invalid shell, rejected$/d' \
   '/^[A-Za-z ]+[0-9: ]+authpriv.warn dropbear\[.+([0-9]+\.){3}[0-9]+/p' \
   '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth.*/p' > "$fileRegex"
-lastPersistentStateWrite="`date +%s`"
+lastPersistentStateWrite="`busybox date +%s`"
 loadState
 bddbCheckStatusAll
 
@@ -455,7 +455,7 @@ if [ "$logMode" = follow ] ; then
     [ -n "$line" ] && processLogLine "$line"
     logLine 3 "ReadComp:$readsSinceSave/$worstCaseReads"
     if [ $((++readsSinceSave)) -ge $worstCaseReads ] ; then
-      now="`date +%s`"
+      now="`busybox date +%s`"
       if [ $((now - lastCheckAll)) -ge $followModeCheckInterval ] ; then
         bddbCheckStatusAll
         lastCheckAll="$now"
@@ -476,7 +476,7 @@ elif [ "$logMode" = entire ] ; then
 elif [ "$logMode" = today ] ; then 
   logLine 1 "Running in today mode"
   # merge the egrep into sed with -e /^$formatTodayLogDateRegex/!d
-  $cmdLogread | egrep "`date +\'$formatTodayLogDateRegex\'`" | sed -nEf "$fileRegex" | while read line ; do 
+  $cmdLogread | egrep "`busybox date +\'$formatTodayLogDateRegex\'`" | sed -nEf "$fileRegex" | while read line ; do 
       processLogLine "$line" 
       saveState
     done
@@ -486,7 +486,7 @@ elif [ "$logMode" = today ] ; then
 elif isValidBindTime "$logMode" ; then
   logInterval=`expandBindTime $logMode`
   logLine 1 "Running in interval mode (reviewing $logInterval seconds of log entries)..."
-  timeStart=$((`date +%s` - logInterval))
+  timeStart=$((`busybox date +%s` - logInterval))
   $cmdLogread | sed -nEf "$fileRegex" | while read line ; do
     timeWhen=`getLogTime "$line"`
     [ $timeWhen -ge $timeStart ] && processLogLine "$line"

--- a/bearDropper
+++ b/bearDropper
@@ -197,7 +197,7 @@ getLogTime () {
 # extra validation, fails safe. Args: $1=log line
 getLogIP () { 
   local logLine="$1"
-  local ebaPID=`echo "$logLine" | sed -n 's/^.*authpriv.info \(dropbear\[[0-9]*\]:\) Exit before auth:.*/\1/p'`
+  local ebaPID=`echo "$logLine" | sed -n 's/^.*authpriv.info \(dropbear\[[0-9]*\]:\) Exit before auth.*/\1/p'`
   [ -n "$ebaPID" ] && logLine=`$cmdLogreadEba | fgrep "${ebaPID} Child connection from "`
   echo "$logLine" | sed -n 's/^.*[^0-9]\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p'
 }
@@ -429,7 +429,7 @@ exitStatus=0
 fileRegex="/tmp/bearDropper.$$.regex"
 uciLoad logRegex 's/[`$"'\\\'']//g' '/has invalid shell, rejected$/d' \
   '/^[A-Za-z ]+[0-9: ]+authpriv.warn dropbear\[.+([0-9]+\.){3}[0-9]+/p' \
-  '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth:.*/p' > "$fileRegex"
+  '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth.*/p' > "$fileRegex"
 lastPersistentStateWrite="`date +%s`"
 loadState
 bddbCheckStatusAll

--- a/src/bearDropper.sh
+++ b/src/bearDropper.sh
@@ -108,7 +108,7 @@ getLogTime () {
 # extra validation, fails safe. Args: $1=log line
 getLogIP () { 
   local logLine="$1"
-  local ebaPID=`echo "$logLine" | sed -n 's/^.*authpriv.info \(dropbear\[[0-9]*\]:\) Exit before auth:.*/\1/p'`
+  local ebaPID=`echo "$logLine" | sed -n 's/^.*authpriv.info \(dropbear\[[0-9]*\]:\) Exit before auth.*/\1/p'`
   [ -n "$ebaPID" ] && logLine=`$cmdLogreadEba | fgrep "${ebaPID} Child connection from "`
   echo "$logLine" | sed -n 's/^.*[^0-9]\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p'
 }
@@ -340,7 +340,7 @@ exitStatus=0
 fileRegex="/tmp/bearDropper.$$.regex"
 uciLoad logRegex 's/[`$"'\\\'']//g' '/has invalid shell, rejected$/d' \
   '/^[A-Za-z ]+[0-9: ]+authpriv.warn dropbear\[.+([0-9]+\.){3}[0-9]+/p' \
-  '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth:.*/p' > "$fileRegex"
+  '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth.*/p' > "$fileRegex"
 lastPersistentStateWrite="`date +%s`"
 loadState
 bddbCheckStatusAll

--- a/src/config/bearDropper
+++ b/src/config/bearDropper
@@ -54,7 +54,7 @@ config bearDropper
     list	logRegex '/has invalid shell, rejected$/d'	# delete (/d) - use to filter out
     # print (/p) - use to filter in 
     list	logRegex '/^[A-Za-z ]+[0-9: ]+authpriv.warn dropbear\[.+([0-9]+\.){3}[0-9]+/p'
-    list	logRegex '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth:.*/p'
+    list	logRegex '/^[A-Za-z ]+[0-9: ]+authpriv.info dropbear\[.+:\ Exit before auth.*/p'
 
   # whitelist entries do not work yet; as a temporary workaround, put in a firewall rule upstream
   #


### PR DESCRIPTION
`bearDropper.sh` currently fails on line 104 when `coreutils-date` is installed, because the GNU `date` command does not support the `-D` option.

The solution is to explicitly specify the `busybox date` command instead of just `date`. I think the change is only _required_ on line 104, but I would suggest changing all the places where `date` is used, for consistency.